### PR TITLE
Feature/item6/api admin logs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from datetime import datetime
@@ -130,3 +130,54 @@ def admin_login(login_data: LoginRequest):
     else:
         print(f"🔒 [로그인 실패] 관리자: {login_data.username}")
         raise HTTPException(status_code=401, detail="아이디 또는 비밀번호가 틀렸습니다.")
+
+
+# ==========================
+
+# 📋 관리자 로그 조회 API (GET)
+
+# ==========================
+
+@app.get("/api/admin/logs")
+
+def get_logs(authorization: str = Header(None)):
+
+    # 1. 토큰 검사 (Security Check)
+
+    # 프론트엔드가 보낸 암호가 우리가 발급한 것과 맞는지 확인
+
+    if authorization != "Bearer fake-jwt-token-v2":
+
+        print(f"🚫 [접근 거부] 잘못된 토큰: {authorization}")
+
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
+   
+
+    conn = get_db_connection()
+
+
+
+    # 2. 최신순으로 정렬해서 가져오기
+
+    rows = conn.execute("SELECT * FROM consent_logs ORDER BY timestamp DESC").fetchall()
+
+    conn.close()
+
+
+
+    # 3. 데이터 변환 (SQLite Row -> Dictionary List)
+
+    logs = [dict(row) for row in rows]
+
+
+
+    print(f"📋 [관리자 조회] 로그 {len(logs)}개 전송 완료")
+
+    return {
+
+        "status": "success",
+
+        "data": logs
+
+    }


### PR DESCRIPTION
## 📌 개요 (Overview)
* **관련 이슈**: #6 관리자 로그 조회 API 구현
* **목적**: 관리자가 키오스크의 결제 및 성인 인증 동의 내역을 최신순으로 조회할 수 있는 보안 API를 구현했습니다.

## 🛠️ 변경 사항 (Changes)

### 1. 로그 조회 API (`GET /api/admin/logs`)
* **기능**: `consent_logs` 테이블의 모든 데이터를 조회하여 반환합니다.
* **정렬 로직**: 최신 데이터가 상단에 오도록 SQL 쿼리에 `ORDER BY timestamp DESC`를 적용했습니다.
* **보안(Security)**:
    * `Header`를 통해 전달된 `Authorization` 토큰 값을 검증합니다.
    * 유효한 토큰(`Bearer fake-jwt-token-v2`)이 아니거나 헤더가 누락된 경우 `401 Unauthorized` 에러를 반환하여 비인가 접근을 차단합니다.

## 📚 기술적 이슈 및 해결 (Troubleshooting)
* **Swagger UI 버그**: 로컬 테스트 시 Swagger UI에서 `Authorization` 헤더가 전송되지 않는 이슈가 있었습니다.
* **해결**: `curl` 명령어를 사용하여 헤더가 정상적으로 서버에 도달함을 확인했고, API 로직이 정상 작동함을 검증했습니다.

## ✅ 테스트 방법 (How to Test)
**참고**: Swagger UI 버그로 인해 **터미널(Curl)** 테스트를 권장합니다.

**1. 실패 테스트 (권한 없음)**
* 명령어: `curl -X 'GET' "http://127.0.0.1:8000/api/admin/logs"`
* 결과: `{"detail":"로그인이 필요합니다."}` (401 Unauthorized)

**2. 성공 테스트 (정상 조회)**
* 명령어:
    ```bash
    curl -X 'GET' "[http://127.0.0.1:8000/api/admin/logs](http://127.0.0.1:8000/api/admin/logs)" \
      -H "accept: application/json" \
      -H "authorization: Bearer fake-jwt-token-v2"
    ```
* 결과: `200 OK` 및 JSON 형태의 로그 데이터 리스트 반환.